### PR TITLE
Fix/create swatch invalid data

### DIFF
--- a/src/pages/api/post/readPosts.ts
+++ b/src/pages/api/post/readPosts.ts
@@ -23,7 +23,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const posts = await getPostSummariesDB(true, skip);
     return res.status(200).json({ posts });
   } catch (err) {
-    console.error('>>>>', err);
     return res.status(500).json({ posts: null });
   }
 }

--- a/src/pages/api/swatch/createSwatch.ts
+++ b/src/pages/api/swatch/createSwatch.ts
@@ -32,14 +32,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       email === session?.user?.email &&
       validateWithRules(data, createSwatchRules);
     if (!isValid) {
-      console.error(
-        'Create Swatch Invalid Data',
-        email,
-        userMeta?.active,
-        session?.user?.email,
-        validateWithRules(data, createSwatchRules),
-        data,
-      );
       throw 'invalid data';
     }
     const colorScore = getColorScore({ r: colorR, g: colorG, b: colorB });
@@ -67,7 +59,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
     return res.status(200).json({ success, swatch: swatchExt });
   } catch (err) {
-    console.log('Create Swatch Error', err);
     return res.status(500).json({ success: false, swatch: null });
   }
 }

--- a/src/pages/api/swatch/createSwatch.ts
+++ b/src/pages/api/swatch/createSwatch.ts
@@ -32,6 +32,14 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       email === session?.user?.email &&
       validateWithRules(data, createSwatchRules);
     if (!isValid) {
+      console.error(
+        'Create Swatch Invalid Data',
+        email,
+        userMeta?.active,
+        session?.user?.email,
+        validateWithRules(data, createSwatchRules),
+        data,
+      );
       throw 'invalid data';
     }
     const colorScore = getColorScore({ r: colorR, g: colorG, b: colorB });
@@ -59,6 +67,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
     return res.status(200).json({ success, swatch: swatchExt });
   } catch (err) {
+    console.log('Create Swatch Error', err);
     return res.status(500).json({ success: false, swatch: null });
   }
 }

--- a/src/validation/swatchRules.ts
+++ b/src/validation/swatchRules.ts
@@ -3,14 +3,14 @@ import { REQ, COLOR_CHANNEL_VAL } from './ruleConstants';
 export const createSwatchRules = [
   {
     field: 'colorR',
-    rules: [REQ, COLOR_CHANNEL_VAL],
+    rules: [COLOR_CHANNEL_VAL],
   },
   {
     field: 'colorG',
-    rules: [REQ, COLOR_CHANNEL_VAL],
+    rules: [COLOR_CHANNEL_VAL],
   },
   {
     field: 'colorB',
-    rules: [REQ, COLOR_CHANNEL_VAL],
+    rules: [COLOR_CHANNEL_VAL],
   },
 ];


### PR DESCRIPTION
## Description
- Hotfix: some swatches are not saving during the creation process

## Changes
- Updated createSwatch rules to remove REQ because the COLOR_CHANNEL_VAL makes sure the value exists, and the REQ rule will fail if the color channel value is 0, which is a valid value.
- Validated fix by posting full 0,0,0 black color multiple times.